### PR TITLE
removed text-decoration-thickness from shorthand

### DIFF
--- a/files/en-us/web/css/text-decoration/index.md
+++ b/files/en-us/web/css/text-decoration/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.text-decoration
 ---
 {{CSSRef}}
 
-The **`text-decoration`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property sets the appearance of decorative lines on text. It is a shorthand for {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-style")}}, and the newer {{cssxref("text-decoration-thickness")}} property.
+The **`text-decoration`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property sets the appearance of decorative lines on text. It is a shorthand for {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, and {{cssxref("text-decoration-style")}} properties.
 
 {{EmbedInteractiveExample("pages/css/text-decoration.html")}}
 
@@ -24,7 +24,6 @@ This property is a shorthand for the following CSS properties:
 - [`text-decoration-color`](/en-US/docs/Web/CSS/text-decoration-color)
 - [`text-decoration-line`](/en-US/docs/Web/CSS/text-decoration-line)
 - [`text-decoration-style`](/en-US/docs/Web/CSS/text-decoration-style)
-- [`text-decoration-thickness`](/en-US/docs/Web/CSS/text-decoration-thickness)
 
 ## Syntax
 
@@ -50,8 +49,6 @@ The `text-decoration` property is specified as one or more space-separated value
   - : Sets the color of the decoration.
 - {{cssxref("text-decoration-style")}}
   - : Sets the style of the line used for the decoration, such as `solid`, `wavy`, or `dashed`.
-- {{cssxref("text-decoration-thickness")}}
-  - : Sets the thickness of the line used for the decoration.
 
 ## Formal definition
 
@@ -60,6 +57,8 @@ The `text-decoration` property is specified as one or more space-separated value
 ## Formal syntax
 
 {{csssyntax}}
+
+> **Note:** {{cssxref("text-decoration-thickness")}} was implemented as part of the shorthand `text-decoration` property in some browsers, but not all. Including it will cause the entire declaration to fail in non-supporting browsers.
 
 ## Examples
 
@@ -85,14 +84,6 @@ The `text-decoration` property is specified as one or more space-separated value
 .underover {
   text-decoration: dashed underline overline;
 }
-
-.thick {
-  text-decoration: solid underline purple 4px;
-}
-
-.blink {
-  text-decoration: blink;
-}
 ```
 
 ```html
@@ -104,9 +95,6 @@ The `text-decoration` property is specified as one or more space-separated value
     the text decoration on anchors since users often depend on
     the underline to denote hyperlinks.</p>
 <p class="underover">This text has lines above <em>and</em> below it.</p>
-<p class="thick">This text has a really thick purple underline in supporting browsers.</p>
-<p class="blink">This text might blink for you,
-    depending on the browser you use.</p>
 ```
 
 {{EmbedLiveSample('Examples','auto','320')}}
@@ -121,6 +109,6 @@ The `text-decoration` property is specified as one or more space-separated value
 
 ## See also
 
-- The individual text-decoration properties are {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-style")}}, and {{cssxref("text-decoration-thickness")}}.
-- The {{cssxref("text-decoration-skip-ink")}}, {{cssxref("text-underline-offset")}}, and {{cssxref("text-underline-position")}} properties also affect text-decoration, but are not included in the shorthand.
+- The individual text-decoration properties are {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, and {{cssxref("text-decoration-style")}}
+- The {{cssxref("text-decoration-thickness")}}, {{cssxref("text-decoration-skip-ink")}}, {{cssxref("text-underline-offset")}}, and {{cssxref("text-underline-position")}} properties also affect text-decoration, but are not included in the shorthand.
 - The {{cssxref("list-style")}} attribute controls the appearance of items in HTML {{HTMLElement("ol")}} and {{HTMLElement("ul")}} lists.


### PR DESCRIPTION
https://drafts.csswg.org/css-text-decor/#text-decoration-property 

text-decoration-thickness is not part of the shorthand.
including it will make the declaration fail in safari.

Also, blink is deprecated as a text-decoration-style, and since it renders a none in most browsers, killed it as an example.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
